### PR TITLE
Fix: update regex pattern to also match grade D & E

### DIFF
--- a/src/app/v3/page.tsx
+++ b/src/app/v3/page.tsx
@@ -30,7 +30,7 @@ export default function V3() {
   const [GPA, setGPA] = useState(0);
 
   const HandleTextChange = (text: string) => {
-    const matchGPA = /\s(\d)\s*([ABCFX][+-]*)/g;
+    const matchGPA = /\s(\d)\s*([ABCDEFX][+-]*)/g;
     const matchResults = Array.from(text.matchAll(matchGPA));
 
     let credits = 0;


### PR DESCRIPTION
In [@53ca7de](https://github.com/viiccwen/GPA-calculator/commit/53ca7de02a655a82e25a189d97a714745c7c89bc), grade `D` and `E` are added to the calculator but in v3, the corresponding regex pattern is unchanged.

This PR updates the regex pattern.