### PR TITLE
fix: correct credit value for level D in points configuration

### DIFF
--- a/src/lib/points.ts
+++ b/src/lib/points.ts
@@ -46,7 +46,7 @@ export const level_points = [
   },
   {
     level: "D",
-    credit: "0",
+    credit: "1.0",
     grade: "50~59",
   },
   {


### PR DESCRIPTION
This pull request updates the credit value for level "D" in the `level_points` array. The change ensures that level "D" now correctly reflects a credit of "1.0" instead of "0".

* Updated the `credit` field for level "D" in the `level_points` array in `src/lib/points.ts` from "0" to "1.0".

Following image reference is school announcement.

<img width="885" height="754" alt="Arc 2026-02-10 at 03 41 02@2x" src="https://github.com/user-attachments/assets/eac38da1-a8a6-4e66-aeff-624295662933" />
